### PR TITLE
Fix for cases where PhysBone root isn't set

### DIFF
--- a/Packages/net.euan.lazyoptimiser/Editor/RemoveUnusedGameObjects.cs
+++ b/Packages/net.euan.lazyoptimiser/Editor/RemoveUnusedGameObjects.cs
@@ -206,7 +206,7 @@ namespace LazyOptimiser
             if (rootTransform == null)
                 rootTransform = physBone.transform;
 
-            List<Transform> usedTransforms = physBone.rootTransform.GetComponentsInChildren<Transform>().ToList();
+            List<Transform> usedTransforms = rootTransform.GetComponentsInChildren<Transform>().ToList();
 
             foreach (var excludedGameobject in physBone.ignoreTransforms)
             {

--- a/Packages/net.euan.lazyoptimiser/Editor/RemoveUnusedGameObjects.cs
+++ b/Packages/net.euan.lazyoptimiser/Editor/RemoveUnusedGameObjects.cs
@@ -201,10 +201,10 @@ namespace LazyOptimiser
 
         private static void UsedGameobjectsInPhysBone(VRCPhysBone physBone, HashSet<Object> usedGameObjects)
         {
-            if (physBone.rootTransform == null)
-            {
-                return;
-            }
+            Transform rootTransform = physBone.rootTransform;
+
+            if (rootTransform == null)
+                rootTransform = physBone.transform;
 
             List<Transform> usedTransforms = physBone.rootTransform.GetComponentsInChildren<Transform>().ToList();
 


### PR DESCRIPTION
When the root transform of a physbone script is not set, the physbone will apply to the gameobject to which it is attached.
The script currently does not iterate transforms under a physbone when this is the case, which can be important for end bones which may not skin a mesh. (and would therefore be removed)

This resolves this issue by using the GameObject transform if the physbone root transform is not set.